### PR TITLE
Add support for header arguments `:php'

### DIFF
--- a/ob-php.el
+++ b/ob-php.el
@@ -45,7 +45,10 @@
 (defun org-babel-execute:php (body params)
   "Execute a block of PHP code with Babel.
 This function is called by `org-babel-execute-src-block'."
-  (let* ((session (org-babel-php-initiate-session (cdr (assoc :session params))))
+  (let* ((org-babel-php-command
+            (or (cdr (assq :php params))
+                org-babel-php-command))
+         (session (org-babel-php-initiate-session (cdr (assoc :session params))))
          (result-params (cdr (assoc :result-params params)))
          (result-type (cdr (assoc :result-type params)))
          (full-body (org-babel-expand-body:generic


### PR DESCRIPTION
```org-mode
#+BEGIN_SRC php :results output :php /usr/local/opt/php56/bin/php
echo phpversion();
#+END_SRC

#+RESULTS:
: 5.6.33

#+BEGIN_SRC php :results output :php /usr/local/opt/php70/bin/php
echo phpversion();
#+END_SRC

#+RESULTS:
: 7.0.27
```
